### PR TITLE
Update foo.mdx

### DIFF
--- a/foo.mdx
+++ b/foo.mdx
@@ -12,7 +12,7 @@ few steps. Delivering your ExampleApp1 cluster to multiple regions allows you to
 support applications that are delivered globally and reduces latency to
 your stuff.
 
-ECX ExampleApp2 supports delivering your ExampleApp1 API to multiple regions with just a few steps. Delivering your ExampleApp1 API to multiple regions allows you to support applications that are delivered globally and reduces latency to your application.
+ECD ExampleApp2 supports delivering your ExampleApp1 API to multiple regions with just a few steps. Delivering your ExampleApp1 API to multiple regions allows you to support applications that are delivered globally and reduces latency to your application.
 
 ## What is performance Feature2?
 

--- a/foo.mdx
+++ b/foo.mdx
@@ -12,7 +12,7 @@ few steps. Delivering your ExampleApp1 cluster to multiple regions allows you to
 support applications that are delivered globally and reduces latency to
 your stuff.
 
-ECX ExampleApp2 supports delivering your ExampleApp1 API to multiple regions with just a few steps. Delivering your ExampleApp1 API to multiple regions allows you to support applications that are delivered globally and reduces latency to your stuff.
+ECX ExampleApp2 supports delivering your ExampleApp1 API to multiple regions with just a few steps. Delivering your ExampleApp1 API to multiple regions allows you to support applications that are delivered globally and reduces latency to your application.
 
 ## What is performance Feature2?
 


### PR DESCRIPTION
Why hard line breaks are better than soft line breaks for markdown code to render content.

Two suggestions on a single line will not work because the content, after applying the first suggestion, is now different. This renders the second suggestion unusable without manual intervention, breaking the Git workflow.

1. Two suggestions made on the same line.
1. Suggestion one committed in 815fa0d4c1785590d58c2064c33e5425964c0bf3
1. Second suggestion can no longer be committed because 815fa0d4c1785590d58c2064c33e5425964c0bf3 changed the content of the line `Outdated suggestions cannot be applied`.